### PR TITLE
Support for the 'type' parameter of the Statement Request has been added:

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ print(f"Valid webhook signature: {valid}")
 
 ## Run tests
 
+Before run integration tests [test/test_get_account_statement.py]:
+
+1. Get sandbox api key according [the docs here](https://api-docs.transferwise.com/#payouts-guide-api-access)
+2. Set an environment variable 'TRANSFERWISE_API_KEY' with a value of your sandbox api key. 
 ```bash
 # Within the pytransferwise working directory
 poetry install

--- a/README.md
+++ b/README.md
@@ -48,8 +48,10 @@ print(f"Valid webhook signature: {valid}")
 
 ## Run tests
 
-Before run integration tests [test/test_get_account_statement.py]:
+Before run integration tests:
+- test/test_get_account_statement.py
 
+please perform the steps:
 1. Get sandbox api key according [the docs here](https://api-docs.transferwise.com/#payouts-guide-api-access)
 2. Set an environment variable 'TRANSFERWISE_API_KEY' with a value of your sandbox api key. 
 ```bash

--- a/googleapi/cloud_storage_api.py
+++ b/googleapi/cloud_storage_api.py
@@ -1,0 +1,17 @@
+from config import BUCKET
+from google.cloud import storage
+
+storage_client = storage.Client()
+bucket = storage_client.get_bucket(BUCKET)
+
+
+def download_blob(source_blob_name, destination_file_name):
+    """Downloads a blob from the bucket."""
+    blob = bucket.blob(source_blob_name)
+    blob.download_to_filename(destination_file_name)
+
+    print('Blob {} downloaded to {}'.format(
+        source_blob_name,
+        destination_file_name))
+
+

--- a/pytransferwise/__init__.py
+++ b/pytransferwise/__init__.py
@@ -8,11 +8,13 @@ class Client(object):
         from pytransferwise.profile import Profile
         from pytransferwise.subscription import Subscription
         from pytransferwise.user import User
+        from pytransferwise.rates import Rates
 
         self.borderless_accounts = BorderlessAccount()
         self.profiles = Profile()
         self.subscriptions = Subscription()
         self.users = User()
+        self.rates = Rates()
 
     def __init__(self):
         if api_key is None:

--- a/pytransferwise/borderless_account.py
+++ b/pytransferwise/borderless_account.py
@@ -28,7 +28,7 @@ class BorderlessAccount(object):
                     "currency": currency,
                     "intervalStart": interval_start,
                     "intervalEnd": interval_end,
-                    "type": statement_type
+                    "type": statement_type,
                 },
             )
         )

--- a/pytransferwise/borderless_account.py
+++ b/pytransferwise/borderless_account.py
@@ -1,7 +1,9 @@
+import requests
 from apiron import JsonEndpoint
 from munch import munchify
 
 from pytransferwise.base import Base
+from pytransferwise import sca
 
 
 class BorderlessAccountService(Base):
@@ -13,22 +15,47 @@ class BorderlessAccountService(Base):
 
 
 class BorderlessAccount(object):
-
     service = BorderlessAccountService()
 
     def list(self, profile_id):
         return munchify(self.service.list(params={"profileId": profile_id}))
 
     def statement(self, profile_id, account_id, currency, interval_start, interval_end, statement_type='COMPACT'):
-        return munchify(
-            self.service.statement(
+        try:  # apiron lib call response.raise_for_status() ans has no option to switch it off
+            r = self.service.statement(
                 profile_id=profile_id,
                 account_id=account_id,
                 params={
                     "currency": currency,
                     "intervalStart": interval_start,
                     "intervalEnd": interval_end,
-                    "type": statement_type,
+                    "type": statement_type
                 },
+                return_raw_response_object=True  # Set this to analyze response status code for 403 in case of SCA
             )
-        )
+        except requests.exceptions.HTTPError as e:
+            r = e.response
+
+            # Adopted from https://github.com/jtrotsky/tw-sca-signatures/blob/main/get-statements-sca.py
+            # 403 with 'x-2fa-approval' header means that TW server ask for SCA
+            if r.status_code == 403 and r.headers.get('x-2fa-approval') is not None:
+                one_time_token = r.headers.get('x-2fa-approval')
+                self.service = sca.add_sca_headers(self.service, one_time_token)
+                return munchify(
+                    self.service.statement(
+                        profile_id=profile_id,
+                        account_id=account_id,
+                        params={
+                            "currency": currency,
+                            "intervalStart": interval_start,
+                            "intervalEnd": interval_end,
+                            "type": statement_type
+                        },
+                        return_raw_response_object=False
+                    )
+                )
+            else:
+                return munchify(r.json())
+        else:
+            if r.status_code == 200 or r.status_code == 201:
+                return munchify(r.json())

--- a/pytransferwise/borderless_account.py
+++ b/pytransferwise/borderless_account.py
@@ -8,7 +8,7 @@ class BorderlessAccountService(Base):
     list = JsonEndpoint(path="/v1/borderless-accounts", required_params=["profileId"])
     statement = JsonEndpoint(
         path="/v3/profiles/{profile_id}/borderless-accounts/{account_id}/statement.json",
-        required_params=["currency", "intervalStart", "intervalEnd"],
+        required_params=["currency", "intervalStart", "intervalEnd", "type"],
     )
 
 
@@ -19,7 +19,7 @@ class BorderlessAccount(object):
     def list(self, profile_id):
         return munchify(self.service.list(params={"profileId": profile_id}))
 
-    def statement(self, profile_id, account_id, currency, interval_start, interval_end):
+    def statement(self, profile_id, account_id, currency, interval_start, interval_end, statement_type='COMPACT'):
         return munchify(
             self.service.statement(
                 profile_id=profile_id,
@@ -28,6 +28,7 @@ class BorderlessAccount(object):
                     "currency": currency,
                     "intervalStart": interval_start,
                     "intervalEnd": interval_end,
+                    "type": statement_type
                 },
             )
         )

--- a/pytransferwise/rates.py
+++ b/pytransferwise/rates.py
@@ -1,0 +1,31 @@
+import requests
+from apiron import JsonEndpoint
+from munch import munchify
+
+from pytransferwise.base import Base
+
+
+class RatesService(Base):
+    list = JsonEndpoint(path="/v1/rates")
+
+
+class Rates(object):
+    service = RatesService()
+
+    def list(self, **kwargs):
+
+        def lookup_param_names(p):
+            return {
+                    p == 'date_from': 'from',
+                    p == 'date_to': 'to',
+                    p not in ['date_from', 'date_to']: p
+            }[True]
+
+        if not kwargs:
+            return munchify(self.service.list())
+        else:
+            params = {}
+            for k in kwargs:
+                k_l = lookup_param_names(k)
+                params[k_l] = kwargs[k]
+            return munchify(self.service.list(params=params))

--- a/pytransferwise/sca.py
+++ b/pytransferwise/sca.py
@@ -1,0 +1,57 @@
+import os
+import base64
+import rsa
+import googleapi.cloud_storage_api as gcsapi
+
+# TODO: implement storing/loading private key from more secret place like Google KMS
+def download_key_file():
+    cloud_storage_tw_key_dir = os.environ['TW_KEY_DIR']
+    _key_fname = os.environ['TW_KEY_NAME'] + '.pem'
+
+    # export_dir = './tmp/' # Only windows env debug
+    export_dir = os.environ['TW_KEY_EXPORT_DIR']
+
+    _key_path = export_dir + _key_fname
+
+    gcsapi.download_blob(cloud_storage_tw_key_dir + _key_fname, _key_path)
+    # print(f'{_key_fname} has been downloaded to {_key_path}')
+    return _key_path
+
+private_key_path = download_key_file()
+# private_key_path = './e_tw_sca_rsa_private.pem' # Only debug option
+
+if os.path.exists(private_key_path) is False:
+    print(f'Private key file not found in {private_key_path}, please check ENV configuration')
+
+# Read the private key file as bytes.
+with open(private_key_path, 'rb') as f:
+    private_key_data = f.read()
+
+private_key = rsa.PrivateKey.load_pkcs1(private_key_data, 'PEM')
+
+
+def add_sca_headers(service, one_time_token):
+    signature = do_sca_challenge(one_time_token)
+    sca_headers = {
+        'x-2fa-approval': one_time_token,
+        'X-Signature': signature
+    }
+    service.required_headers.update(sca_headers)
+    return service
+
+
+def do_sca_challenge(one_time_token):
+    print('doing sca challenge')
+
+    # Use the private key to sign the one-time-token that was returned
+    # in the x-2fa-approval header of the HTTP 403.
+    signed_token = rsa.sign(
+        one_time_token.encode('ascii'),
+        private_key,
+        'SHA-256')
+
+    # Encode the signed message as friendly base64 format for HTTP
+    # headers.
+    signature = base64.b64encode(signed_token).decode('ascii')
+
+    return signature

--- a/test/test_get_account_statement.py
+++ b/test/test_get_account_statement.py
@@ -3,10 +3,12 @@ import pytest
 
 import pytransferwise
 
-pytransferwise.api_key = os.getenv('TRANSFERWISE_API_KEY')
-# print('Get value of TRANSFERWISE_API_KEY: {}'.format(pytransferwise.api_key))
 
-client = pytransferwise.Client()
+@pytest.fixture
+def client():
+    pytransferwise.api_key = os.getenv('TRANSFERWISE_API_KEY')
+    # print('Get value of TRANSFERWISE_API_KEY: {}'.format(pytransferwise.api_key))
+    return pytransferwise.Client()
 
 
 @pytest.fixture()
@@ -19,7 +21,10 @@ def interval_end():
     return '2020-08-01T23:59:59.999Z'
 
 
-def test_get_statement_with_default_type_compact(interval_start, interval_end):
+client = client()
+
+
+def test_get_statement_with_default_type_compact(client, interval_start, interval_end):
     """
     This is the smoke test of passing the optional parameter type 'COMPACT'
     The test does not check the logic of passed type value.
@@ -40,7 +45,7 @@ def test_get_statement_with_default_type_compact(interval_start, interval_end):
     assert statements  # after the test execution we expect have {statements} as non empty list
 
 
-def test_get_statement_with_type_flat(interval_start, interval_end):
+def test_get_statement_with_type_flat(client, interval_start, interval_end):
     """
     This is the smoke test of passing the optional parameter type or 'FLAT'
     The test does not check the logic of passed type value.

--- a/test/test_get_account_statement.py
+++ b/test/test_get_account_statement.py
@@ -1,0 +1,63 @@
+import os
+import pytest
+
+import pytransferwise
+
+pytransferwise.api_key = os.getenv('TW_API_KEY')
+# print('Get value of TW_API_KEY: {}'.format(pytransferwise.api_key))
+pytransferwise.environment = "live"
+
+client = pytransferwise.Client()
+
+
+@pytest.fixture()
+def interval_start():
+    return '2020-08-01T00:00:00.000Z'
+
+
+@pytest.fixture()
+def interval_end():
+    return '2020-08-01T23:59:59.999Z'
+
+
+def test_get_statement_with_default_type_compact(interval_start, interval_end):
+    """
+    This is the smoke test of passing the optional parameter type 'COMPACT'
+    The test does not check the logic of passed type value.
+    """
+    statements = []
+    for profile in client.profiles.list():
+        accounts = client.borderless_accounts.list(profile_id=profile.id)
+        for account in accounts:
+            currencies = [balance.currency for balance in account.balances]
+            print(f"AccountID={account.id}, Currencies={currencies}")
+            for currency in currencies:
+                statement = client.borderless_accounts.statement(profile_id=profile.id,
+                                                                 account_id=account.id,
+                                                                 currency=currency,
+                                                                 interval_start=interval_start,
+                                                                 interval_end=interval_end)
+                statements.append(statement)
+    assert statements  # after the test execution we expect have {statements} as non empty list
+
+
+def test_get_statement_with_type_flat(interval_start, interval_end):
+    """
+    This is the smoke test of passing the optional parameter type or 'FLAT'
+    The test does not check the logic of passed type value.
+    """
+    statements = []
+    for profile in client.profiles.list():
+        accounts = client.borderless_accounts.list(profile_id=profile.id)
+        for account in accounts:
+            currencies = [balance.currency for balance in account.balances]
+            print(f"AccountID={account.id}, Currencies={currencies}")
+            for currency in currencies:
+                statement = client.borderless_accounts.statement(profile_id=profile.id,
+                                                                 account_id=account.id,
+                                                                 currency=currency,
+                                                                 interval_start=interval_start,
+                                                                 interval_end=interval_end,
+                                                                 statement_type='FLAT')
+                statements.append(statement)
+    assert statements  # after the test execution we expect have {statements} as non empty list

--- a/test/test_get_account_statement.py
+++ b/test/test_get_account_statement.py
@@ -3,9 +3,8 @@ import pytest
 
 import pytransferwise
 
-pytransferwise.api_key = os.getenv('TW_API_KEY')
-# print('Get value of TW_API_KEY: {}'.format(pytransferwise.api_key))
-pytransferwise.environment = "live"
+pytransferwise.api_key = os.getenv('TRANSFERWISE_API_KEY')
+# print('Get value of TRANSFERWISE_API_KEY: {}'.format(pytransferwise.api_key))
 
 client = pytransferwise.Client()
 


### PR DESCRIPTION
According to documentation [Get account statement -> Request](https://api-docs.transferwise.com/#payouts-guide-check-account-balance) there is optional parameter:

type (optional)
COMPACT (default) for a single statement line per transaction. FLAT for accounting statements where transaction fees are on a separate line.
Text

I add it into params list of BorderlessAccountService class.