### PR TITLE
Move `api_key` and `environment` initialization to `Client` class

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,7 @@ poetry add pywisetransfer
 ```python
 import pywisetransfer
 
-pywisetransfer.api_key = "your-api-key-here"
-# pywisetransfer.environment = "live"
-
-client = pywisetransfer.Client()
+client = pywisetransfer.Client(api_key="your-api-key-here")
 
 for profile in client.profiles.list():
     accounts = client.borderless_accounts.list(profile_id=profile.id)
@@ -36,8 +33,6 @@ for profile in client.profiles.list():
 import pywisetransfer
 from pywisetransfer.webhooks import verify_signature
 
-# pywisetransfer.environment = "live"
-
 payload = b"webhook-request-body-here"
 signature = "webhook-signature-data-here"
 
@@ -51,5 +46,5 @@ print(f"Valid webhook signature: {valid}")
 ```bash
 # Within the pywisetransfer working directory
 poetry install
-poetry run pytest --forked
+poetry run pytest
 ```

--- a/pywisetransfer/__init__.py
+++ b/pywisetransfer/__init__.py
@@ -1,7 +1,3 @@
-api_key = None
-environment = "sandbox"
-
-
 class Client(object):
     def add_resources(self):
         from pywisetransfer.borderless_account import BorderlessAccount
@@ -9,16 +5,18 @@ class Client(object):
         from pywisetransfer.subscription import Subscription
         from pywisetransfer.user import User
 
-        self.borderless_accounts = BorderlessAccount()
-        self.profiles = Profile()
-        self.subscriptions = Subscription()
-        self.users = User()
+        self.borderless_accounts = BorderlessAccount(client=self)
+        self.profiles = Profile(client=self)
+        self.subscriptions = Subscription(client=self)
+        self.users = User(client=self)
 
-    def __init__(self):
+    def __init__(self, api_key, environment="sandbox"):
         if api_key is None:
             raise KeyError("You must provide a value for pywisetransfer.api_key")
 
         if environment not in ("sandbox", "live"):
             raise KeyError("pywisetransfer.environment must be 'sandbox' or 'live'")
 
+        self.api_key = api_key
+        self.environment = environment
         self.add_resources()

--- a/pywisetransfer/base.py
+++ b/pywisetransfer/base.py
@@ -1,13 +1,20 @@
-from pywisetransfer import api_key, environment
-
 from apiron import Service
 
 
 class Base(Service):
 
-    domain = (
-        "https://api.transferwise.com"
-        if environment == "live"
-        else "https://api.sandbox.transferwise.tech"
-    )
-    required_headers = {"Authorization": f"Bearer {api_key}"}
+    client = None
+
+    def __init__(self, *args, **kwargs):
+        if "client" in kwargs and Base.client != kwargs["client"]:
+            Base.client = kwargs["client"]
+        if Base.client and Base.client.environment == "live":
+            Base.domain = "https://api.transferwise.com"
+        else:
+            Base.domain = "https://api.sandbox.transferwise.tech"
+
+    @property
+    def required_headers(self):
+        if self.client:
+            return {"Authorization": f"Bearer {self.client.api_key}"}
+        return {}

--- a/pywisetransfer/base.py
+++ b/pywisetransfer/base.py
@@ -6,6 +6,11 @@ class Base(Service):
     client = None
 
     def __init__(self, *args, **kwargs):
+        # TODO: It would be nice to make 'client' a required argument here
+        # Currently apiron performs a zero-argument constructor call to the
+        # service base class to retrieve the 'required_headers' property,
+        # so we cater for empty arguments here
+        # https://github.com/ithaka/apiron/blob/v5.1.0/src/apiron/service/base.py#L7
         if "client" in kwargs and Base.client != kwargs["client"]:
             Base.client = kwargs["client"]
         if Base.client and Base.client.environment == "live":

--- a/pywisetransfer/borderless_account.py
+++ b/pywisetransfer/borderless_account.py
@@ -13,8 +13,8 @@ class BorderlessAccountService(Base):
 
 
 class BorderlessAccount(object):
-
-    service = BorderlessAccountService()
+    def __init__(self, client):
+        self.service = BorderlessAccountService(client=client)
 
     def list(self, profile_id):
         return munchify(self.service.list(params={"profileId": profile_id}))

--- a/pywisetransfer/profile.py
+++ b/pywisetransfer/profile.py
@@ -10,7 +10,8 @@ class ProfileService(Base):
 
 
 class Profile(object):
-    service = ProfileService()
+    def __init__(self, client):
+        self.service = ProfileService(client=client)
 
     def list(self, type=None):
         profiles = munchify(self.service.list())

--- a/pywisetransfer/subscription.py
+++ b/pywisetransfer/subscription.py
@@ -10,7 +10,8 @@ class SubscriptionService(Base):
 
 
 class Subscription(object):
-    service = SubscriptionService()
+    def __init__(self, client):
+        self.service = SubscriptionService(client=client)
 
     def list(self, profile_id):
         return munchify(self.service.list(profile_id=profile_id))

--- a/pywisetransfer/user.py
+++ b/pywisetransfer/user.py
@@ -10,7 +10,8 @@ class UserService(Base):
 
 
 class User(object):
-    service = UserService()
+    def __init__(self, client):
+        self.service = UserService(client=client)
 
     def me(self):
         return munchify(self.service.me())

--- a/pywisetransfer/webhooks.py
+++ b/pywisetransfer/webhooks.py
@@ -1,6 +1,5 @@
 from base64 import b64decode
 
-import pywisetransfer
 from pywisetransfer.keys import (
     WEBHOOK_SIGNATURE_PUBLIC_KEY_LIVE,
     WEBHOOK_SIGNATURE_PUBLIC_KEY_SANDBOX,
@@ -13,11 +12,11 @@ from cryptography.hazmat.primitives.asymmetric import padding, utils
 from cryptography.hazmat.primitives.serialization import load_pem_public_key
 
 
-def verify_signature(payload, signature):
+def verify_signature(payload, signature, environment="sandbox"):
     signature = b64decode(signature)
     key_data = (
         WEBHOOK_SIGNATURE_PUBLIC_KEY_LIVE
-        if pywisetransfer.environment == "live"
+        if environment == "live"
         else WEBHOOK_SIGNATURE_PUBLIC_KEY_SANDBOX
     )
     public_key = load_pem_public_key(key_data, backend=default_backend())

--- a/test/test_client_live.py
+++ b/test/test_client_live.py
@@ -1,7 +1,44 @@
-def test_client_live_environment():
+import pytest
+import responses
+
+
+@pytest.fixture
+def me_response():
+    return {
+        "id": 101,
+        "name": "Example Person",
+        "email": "person@example.com",
+        "active": True,
+        "details": {
+            "firstName": "Example",
+            "lastName": "Person",
+            "phoneNumber": "+37111111111",
+            "occupation": "",
+            "address": {
+                "city": "Tallinn",
+                "countryCode": "EE",
+                "postCode": "11111",
+                "state": "",
+                "firstLine": "Road 123",
+            },
+            "dateOfBirth": "1977-01-01",
+            "avatar": "https://lh6.googleusercontent.com/photo.jpg",
+            "primaryAddress": 111,
+        },
+    }
+
+
+@responses.activate
+def test_client_live_environment(me_response):
+    responses.add(
+        responses.GET,
+        "https://api.transferwise.com/v1/me",
+        json=me_response,
+    )
     import pywisetransfer
 
     client = pywisetransfer.Client(api_key="live-key", environment="live")
+    me = client.users.me()
 
     domain = client.borderless_accounts.service.domain
     assert "api.sandbox.transferwise" not in domain

--- a/test/test_client_live.py
+++ b/test/test_client_live.py
@@ -1,9 +1,7 @@
 def test_client_live_environment():
     import pywisetransfer
 
-    pywisetransfer.api_key = "live-key"
-    pywisetransfer.environment = "live"
-    client = pywisetransfer.Client()
+    client = pywisetransfer.Client(api_key="live-key", environment="live")
 
     domain = client.borderless_accounts.service.domain
     assert "api.sandbox.transferwise" not in domain

--- a/test/test_client_sandbox.py
+++ b/test/test_client_sandbox.py
@@ -3,26 +3,18 @@ import pytest
 import pywisetransfer
 
 
-def setup_function(method):
-    pywisetransfer.api_key = None
-    pywisetransfer.environment = "sandbox"
-
-
 def test_client_missing_key():
     with pytest.raises(KeyError, match="pywisetransfer.api_key"):
-        pywisetransfer.Client()
+        pywisetransfer.Client(api_key=None)
 
 
 def test_client_invalid_environment():
-    pywisetransfer.api_key = "test-key"
-    pywisetransfer.environment = "test-environment"
     with pytest.raises(KeyError, match="pywisetransfer.environment"):
-        pywisetransfer.Client()
+        pywisetransfer.Client(api_key="test-key", environment="test-environment")
 
 
 def test_client_default_environment():
-    pywisetransfer.api_key = "test-key"
-    client = pywisetransfer.Client()
+    client = pywisetransfer.Client(api_key="test-key")
 
     domain = client.borderless_accounts.service.domain
     assert "api.sandbox.transferwise" in domain
@@ -30,10 +22,7 @@ def test_client_default_environment():
 
 
 def test_client_domain_immutable():
-    assert pywisetransfer.environment == "sandbox"
-
-    pywisetransfer.api_key = "test-key"
-    client = pywisetransfer.Client()
+    client = pywisetransfer.Client(api_key="test-key", environment="sandbox")
 
     domain = client.borderless_accounts.service.domain
     assert "api.sandbox.transferwise" in domain

--- a/test/test_profile.py
+++ b/test/test_profile.py
@@ -1,7 +1,7 @@
 import pytest
 import responses
 
-from pywisetransfer.profile import Profile
+from pywisetransfer import Client
 
 
 @pytest.fixture
@@ -52,7 +52,7 @@ def test_profile_list_unfiltered(profile_list_response):
         json=profile_list_response,
     )
 
-    endpoint = Profile()
+    endpoint = Client(api_key="test-key").profiles
     results = list(endpoint.list())
 
     assert len(results) == 2
@@ -66,7 +66,7 @@ def test_profile_list_type_filtered(profile_list_response):
         json=profile_list_response,
     )
 
-    endpoint = Profile()
+    endpoint = Client(api_key="test-key").profiles
     results = list(endpoint.list(type="business"))
 
     assert len(results) == 1


### PR DESCRIPTION
Primarily: moves the `api_key` and `environment` client configuration elements from the global module level to the `Client` class initializer.

As a result of these changes, webhook verification becomes [very slightly less convenient](https://github.com/jayaddison/pywisetransfer/commit/0ae87d706dc0fade3616a328b1115bd50e969204#diff-0a87e9850a8203f172f9b8e5d58723491f88cb86f21d4af035dd6c77cf86c4e1R15), albeit more explicit (it requires access to the `environment`, and can no longer read it from module state).  Perhaps webhook verification should be moved onto the `Client` class too -- although preferably without too much `import` pollution.

Resolves #6

cc @marksteward