### PR TITLE
Return a list from profiles.list instead of iterable

### DIFF
--- a/pywisetransfer/profile.py
+++ b/pywisetransfer/profile.py
@@ -14,7 +14,9 @@ class Profile(object):
 
     def list(self, type=None):
         profiles = munchify(self.service.list())
-        return filter(lambda p: type is None or p.type == type, profiles)
+        if type is None:
+            return profiles
+        return [p for p in profiles if p.type == type]
 
     def get(self, profile_id):
         return munchify(self.service.get(profile_id=profile_id))


### PR DESCRIPTION
Instead of leaving this to the caller, it's clearer to do it instead of returning an iterable. The list will never be long enough for performance to be a concern.

I've left the test alone, but list() can now be removed from there too.