### PR TITLE
Add transfers to API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist
 *.egg-info
 *.pyc
 *.swp
+.venv

--- a/pywisetransfer/__init__.py
+++ b/pywisetransfer/__init__.py
@@ -10,6 +10,7 @@ class Client:
         from pywisetransfer.multi_currency_account import MultiCurrencyAccount
         from pywisetransfer.profile import Profile
         from pywisetransfer.subscription import Subscription
+        from pywisetransfer.transfer import Transfer
         from pywisetransfer.user import User
 
         self.account_details = AccountDetails(client=self)
@@ -19,8 +20,9 @@ class Client:
         self.multi_currency_account = MultiCurrencyAccount(client=self)
         self.profiles = Profile(client=self)
         self.subscriptions = Subscription(client=self)
+        self.transfers = Transfer(client=self)
         self.users = User(client=self)
-
+        
     def __init__(
         self,
         api_key: str,

--- a/pywisetransfer/base.py
+++ b/pywisetransfer/base.py
@@ -29,3 +29,20 @@ class Base(Service):
         if self.client:
             return {"Authorization": f"Bearer {self.client.api_key}"}
         return {}
+
+    @staticmethod
+    def get_params_for_endpoint(**kw) -> dict[str, str]:
+        """Return the actual keyword arguments for the endpoint call.
+        
+        >>> Base.get_kw_for_endpoint(profile_id=1)
+        {profileId: '1'}
+        """
+        wise_call_args = {}
+        for py_arg, value in kw.items():
+            wise_arg = "".join(s[0].upper() + s[1:] for s in py_arg.split("_"))
+            wise_arg = wise_arg[0].lower() + wise_arg[1:]
+            if value is not None:
+                wise_call_args[wise_arg] = str(value)
+        return wise_call_args
+
+__all__ = ["Base"]

--- a/pywisetransfer/transfer.py
+++ b/pywisetransfer/transfer.py
@@ -1,0 +1,83 @@
+"""Money Transfers
+
+Get information about transfers.
+
+See https://docs.wise.com/api-docs/api-reference/transfer
+
+"""
+from typing import Optional
+from apiron import JsonEndpoint
+from munch import munchify
+
+from pywisetransfer import Client
+from pywisetransfer.base import Base
+
+
+class TransferService(Base):
+    list = JsonEndpoint(path="/v1/transfers")
+    get = JsonEndpoint(path="/v1/transfers/{transfer_id}")
+
+
+class Transfer:
+    def __init__(self, client: Client):
+        self.service = TransferService(client=client)
+
+    def list(
+            self,
+            profile_id: Optional[int]=None,
+            status: Optional[str]=None,
+            offset: Optional[int]=None,
+            limit: Optional[int]=None,
+            created_date_start: Optional[str]=None,
+            created_date_end: Optional[str]=None,
+            target_currency: Optional[str]=None,
+            source_currency: Optional[str]=None
+            ) -> list[dict]:
+        """Get transfers for a profile.
+        
+        See https://docs.wise.com/api-docs/api-reference/transfer#list
+        
+        Args:
+        
+            profile_id: The optional profile id. Defaults to the current profile.
+            
+            status: Comma separated list of one or more status codes to filter transfers.
+                See Track transfer status for complete list of statuses:
+                https://api-docs.wise.com/api-docs/guides/send-money/tracking
+            
+            offset: Starting record number
+            
+            limit: Maximum number of records to be returned in response
+            
+            created_date_start: yyyy-mm-ddThh:mm:ss.sssZ
+                Starting date to filter transfers, inclusive of the provided date.
+            
+            created_date_end: yyyy-mm-ddThh:mm:ss.sssZ
+                Ending date to filter transfers, inclusive of the provided date.
+            
+            target_currency: Target currency code
+            
+            source_currency: Source currency code
+            
+        
+        Returns:
+            Returns an array of transfer objects, with or without an
+            originator block depending on the type of each transfer.
+            https://docs.wise.com/api-docs/api-reference/transfer#object
+        """
+        params = self.service.get_params_for_endpoint(
+            profile_id=profile_id,
+            status=status,
+            offset=offset,
+            limit=limit,
+            created_date_start=created_date_start,
+            created_date_end=created_date_end,
+            target_currency=target_currency,
+            source_currency=source_currency
+        )
+        return munchify(self.service.list(params=params))
+
+    def get(self, transfer_id: int|str) -> dict:
+        return munchify(self.service.get(transfer_id=str(transfer_id)))
+
+__all__ = ["Subscription"]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,31 @@
+"""pytest configuration
+
+You can add responses by running this in your codebase:
+
+
+"""
+
+from typing import Generator
+import pytest
+from pywisetransfer import Client
+import responses
+from pathlib import Path
+
+HERE = Path(__file__).parent
+RESPONSES = HERE / "responses"
+
+
+@pytest.fixture
+def sandbox() -> Generator[Client, None, None]:
+    """We return a sandbox client and dispatch all requests.
+    
+    The responses are loaded from the RESPONSES directory.
+    
+    """
+    rsps = responses.RequestsMock()
+    rsps.start()
+    # see https://github.com/getsentry/responses?tab=readme-ov-file#replay-responses-populate-registry-from-files
+    for path in RESPONSES.iterdir():
+        rsps._add_from_file(file_path=path)
+    yield Client(api_key="test-key", environment="sandbox")
+    rsps.stop(allow_assert=False)

--- a/test/responses/transfers.yaml
+++ b/test/responses/transfers.yaml
@@ -1,0 +1,83 @@
+responses:
+- response:
+    auto_calculate_content_length: false
+    body: '[{"id":777791907,"user":50372104,"targetAccount":425982826,"sourceAccount":null,"quote":null,"quoteUuid":"5792754a-c3b5-4ce1-98a8-f3fd7df8e344","status":"outgoing_payment_sent","reference":"","rate":1.0,"created":"2023-08-18
+      21:16:22","business":null,"transferRequest":null,"details":{"reference":""},"hasActiveIssues":false,"sourceCurrency":"GBP","sourceValue":20.00,"targetCurrency":"GBP","targetValue":20.00,"customerTransactionId":"c5589626-3c99-4e95-b205-2fd2f0a9857b"}]'
+    content_type: text/plain
+    headers:
+      CF-Cache-Status: DYNAMIC
+      CF-RAY: 8f81f57c7df6cd10-LHR
+      Set-Cookie: __cf_bm=VOUeaP5dfmtz89HTnRgE7CaoJMrWpEgkM_cTMYaLd38-1735225420-1.0.1.1-GL45gnTj6AtFgMOGXO.V3aF9SjaykqD1u_ipJWi2HlzyFOdsyWSTRw1a2_IH7RoFxfYdcyMB8Yg1cJBs0a6_inRSUu6w1UcHdJgpJxfWqkQ;
+        path=/; expires=Thu, 26-Dec-24 15:33:40 GMT; domain=.transferwise.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security: max-age=31536000
+      Transfer-Encoding: chunked
+      alt-svc: h3=":443"; ma=86400
+      cache-control: no-cache, no-store, max-age=0, must-revalidate
+      expires: '0'
+      pragma: no-cache
+      vary: origin,access-control-request-method,access-control-request-headers,accept-encoding
+      x-content-type-options: nosniff
+      x-envoy-attempt-count: '1'
+      x-envoy-upstream-service-time: '64'
+      x-frame-options: DENY
+      x-trace-id: 869b0035178a0a37
+      x-xss-protection: '0'
+    method: GET
+    status: 200
+    url: https://api.sandbox.transferwise.tech/v1/transfers?limit=1
+- response:
+    auto_calculate_content_length: false
+    body: '[{"id":777791907,"user":50372104,"targetAccount":425982826,"sourceAccount":null,"quote":null,"quoteUuid":"5792754a-c3b5-4ce1-98a8-f3fd7df8e344","status":"outgoing_payment_sent","reference":"","rate":1.0,"created":"2023-08-18
+      21:16:22","business":null,"transferRequest":null,"details":{"reference":""},"hasActiveIssues":false,"sourceCurrency":"GBP","sourceValue":20.00,"targetCurrency":"GBP","targetValue":20.00,"customerTransactionId":"c5589626-3c99-4e95-b205-2fd2f0a9857b"},{"id":942411557,"user":50372104,"targetAccount":425982826,"sourceAccount":null,"quote":null,"quoteUuid":"3560685e-4483-48de-a2dc-8144b2234d64","status":"outgoing_payment_sent","reference":"7394529010173945290101No
+      email present/07078000024350","rate":1.0,"created":"2024-01-24 08:06:42","business":null,"transferRequest":null,"details":{"reference":"7394529010173945290101No
+      email present/07078000024350"},"hasActiveIssues":false,"sourceCurrency":"EUR","sourceValue":209.85,"targetCurrency":"EUR","targetValue":209.85,"customerTransactionId":"0d106ac9-ebdb-e906-6a87-dea2282b5c00"},{"id":955921172,"user":50372104,"targetAccount":425982826,"sourceAccount":null,"quote":null,"quoteUuid":"9313b31f-df4b-4819-8527-889fd40174a8","status":"outgoing_payment_sent","reference":"nachtraegliches
+      Geburtstagsgeschenk fuer Nicco","rate":1.0,"created":"2024-02-05 09:22:45","business":null,"transferRequest":null,"details":{"reference":"Gift"},"hasActiveIssues":false,"sourceCurrency":"EUR","sourceValue":200.00,"targetCurrency":"EUR","targetValue":200.00,"customerTransactionId":"0b9fc4aa-0f49-639a-cfbd-2c97748e9dbe"}]'
+    content_type: text/plain
+    headers:
+      CF-Cache-Status: DYNAMIC
+      CF-RAY: 8f81f5f629db3854-LHR
+      Set-Cookie: __cf_bm=HaKLCUFejsxJZ3qlKiw0WrriOx0Mg7HfGUq2FX.cp70-1735225439-1.0.1.1-cDFzgDTIUx0r4No_tL6dfyRylyiCXT8HGlsoUut4QyfA2xWd695IG.Pf1.MbXXt4hu3qQQlWOxbhXhToWMQKDbcFfpEw1qYazSDNmznkeWI;
+        path=/; expires=Thu, 26-Dec-24 15:33:59 GMT; domain=.transferwise.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security: max-age=31536000
+      Transfer-Encoding: chunked
+      alt-svc: h3=":443"; ma=86400
+      cache-control: no-cache, no-store, max-age=0, must-revalidate
+      expires: '0'
+      pragma: no-cache
+      vary: origin,access-control-request-method,access-control-request-headers,accept-encoding
+      x-content-type-options: nosniff
+      x-envoy-attempt-count: '1'
+      x-envoy-upstream-service-time: '68'
+      x-frame-options: DENY
+      x-trace-id: 6fae1283391d3d4d
+      x-xss-protection: '0'
+    method: GET
+    status: 200
+    url: https://api.sandbox.transferwise.tech/v1/transfers
+- response:
+    auto_calculate_content_length: false
+    body: '[{"id":942411557,"user":50372104,"targetAccount":425982826,"sourceAccount":null,"quote":null,"quoteUuid":"3560685e-4483-48de-a2dc-8144b2234d64","status":"outgoing_payment_sent","reference":"7394529010173945290101No
+      email present/07078000024350","rate":1.0,"created":"2024-01-24 08:06:42","business":null,"transferRequest":null,"details":{"reference":"7394529010173945290101No
+      email present/07078000024350"},"hasActiveIssues":false,"sourceCurrency":"EUR","sourceValue":209.85,"targetCurrency":"EUR","targetValue":209.85,"customerTransactionId":"0d106ac9-ebdb-e906-6a87-dea2282b5c00"}]'
+    content_type: text/plain
+    headers:
+      CF-Cache-Status: DYNAMIC
+      CF-RAY: 8f820b1b0ad8369a-LHR
+      Strict-Transport-Security: max-age=31536000
+      Transfer-Encoding: chunked
+      alt-svc: h3=":443"; ma=86400
+      cache-control: no-cache, no-store, max-age=0, must-revalidate
+      expires: '0'
+      pragma: no-cache
+      vary: origin,access-control-request-method,access-control-request-headers,accept-encoding
+      x-content-type-options: nosniff
+      x-envoy-attempt-count: '1'
+      x-envoy-upstream-service-time: '74'
+      x-frame-options: DENY
+      x-trace-id: 741136924d5430b
+      x-xss-protection: '0'
+    method: GET
+    status: 200
+    url: https://api.sandbox.transferwise.tech/v1/transfers?offset=1&limit=1

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -1,0 +1,17 @@
+"""Test the base methods."""
+
+from pywisetransfer.base import Base
+
+def test_kw_conversion():
+    assert Base.get_params_for_endpoint(profile_id=1) == {"profileId": "1"}
+
+
+def test_multiple_kw():
+    assert Base.get_params_for_endpoint(
+            profile_id=1,
+            start=None,
+            initialStart="asd-asd"
+        ) == {
+            "profileId": "1",
+            "initialStart": "asd-asd"
+        }

--- a/test/test_transfer.py
+++ b/test/test_transfer.py
@@ -1,0 +1,15 @@
+"""Test the transfer endpoint."""
+
+def test_list_and_limit_transfers(sandbox):
+    """Test listing the transfers."""
+    transfers = sandbox.transfers.list()
+    assert len(transfers) == 3
+    first_transfer = sandbox.transfers.list(limit=1)
+    assert len(first_transfer) == 1
+    next_transfer = sandbox.transfers.list(limit=1, offset=1)
+    assert len(next_transfer) == 1
+    assert next_transfer[0]["id"] != first_transfer[0]["id"]
+    assert transfers[0]["id"] == first_transfer[0]["id"]
+    assert transfers[1]["id"] == next_transfer[0]["id"]
+    assert transfers[0] == first_transfer[0]
+    assert transfers[1] == next_transfer[0]


### PR DESCRIPTION
Hi, thanks for this module! I am looking forward to using it. However, I would like to add a bit more to it before.
The earlier the features are merged, the earlier I can add on top of them :)

Changes:

- add client.transfers.list
- add client.transfers.get
- ignore .venv (VSCode)
- create tests
- use the new recorder feature of responses to construct an API and keep the tests cases small and simple
